### PR TITLE
Fast skin refreshing for players with the mod installed

### DIFF
--- a/src/main/java/com/mineblock11/skinshuffle/mixin/PlayerEntityMixin.java
+++ b/src/main/java/com/mineblock11/skinshuffle/mixin/PlayerEntityMixin.java
@@ -25,23 +25,26 @@ import com.mineblock11.skinshuffle.client.config.SkinShuffleConfig;
 import com.mineblock11.skinshuffle.client.preset.SkinPreset;
 import com.mineblock11.skinshuffle.networking.ClientSkinHandling;
 import com.mineblock11.skinshuffle.util.NetworkingUtil;
+import com.mineblock11.skinshuffle.util.SkinShuffleClientPlayer;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
+import net.minecraft.client.network.PlayerListEntry;
 import net.minecraft.client.util.SkinTextures;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.Objects;
-
 @Mixin(AbstractClientPlayerEntity.class)
-public abstract class PlayerEntityMixin extends PlayerEntity {
+public abstract class PlayerEntityMixin extends PlayerEntity implements SkinShuffleClientPlayer {
+    @Shadow @Nullable private PlayerListEntry playerListEntry;
+
     protected PlayerEntityMixin(World world, BlockPos pos, float yaw, GameProfile gameProfile) {
         super(world, pos, yaw, gameProfile);
     }
@@ -64,5 +67,10 @@ public abstract class PlayerEntityMixin extends PlayerEntity {
                 cir.setReturnValue(new SkinTextures(currentPreset.getSkin().getTexture(), null, null, null, SkinTextures.Model.fromName(currentPreset.getSkin().getModel()), false));
             }
         }
+    }
+
+    @Override
+    public void skinShuffle$refreshPlayerListEntry() {
+        playerListEntry = null;
     }
 }

--- a/src/main/java/com/mineblock11/skinshuffle/networking/ClientSkinHandling.java
+++ b/src/main/java/com/mineblock11/skinshuffle/networking/ClientSkinHandling.java
@@ -23,9 +23,13 @@ package com.mineblock11.skinshuffle.networking;
 import com.mineblock11.skinshuffle.SkinShuffle;
 import com.mineblock11.skinshuffle.api.SkinQueryResult;
 import com.mineblock11.skinshuffle.client.config.SkinPresetManager;
+import com.mineblock11.skinshuffle.util.SkinShuffleClientPlayer;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.minecraft.client.network.AbstractClientPlayerEntity;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.Entity;
 import net.minecraft.network.PacketByteBuf;
 
 public class ClientSkinHandling {
@@ -70,6 +74,19 @@ public class ClientSkinHandling {
 
         ClientPlayNetworking.registerGlobalReceiver(SkinShuffle.id("handshake"), (client1, handler1, buf, responseSender) -> {
             handshakeTakenPlace = true;
+        });
+
+        ClientPlayNetworking.registerGlobalReceiver(SkinShuffle.id("refresh_player_list_entry"), (client, handler, buf, responseSender) -> {
+            int id = buf.readVarInt();
+            client.execute(() -> {
+                ClientWorld world = client.world;
+                if (world != null) {
+                    Entity entity = world.getEntityById(id);
+                    if (entity instanceof AbstractClientPlayerEntity player) {
+                        ((SkinShuffleClientPlayer) player).skinShuffle$refreshPlayerListEntry();
+                    }
+                }
+            });
         });
     }
 }

--- a/src/main/java/com/mineblock11/skinshuffle/networking/ServerSkinHandling.java
+++ b/src/main/java/com/mineblock11/skinshuffle/networking/ServerSkinHandling.java
@@ -31,8 +31,11 @@ import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
 
 public class ServerSkinHandling {
+    private static final Identifier REFRESH_PLAYER_LIST_ENTRY_ID = SkinShuffle.id("refresh_player_list_entry");
+
     private static void handleSkinRefresh(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
         Property skinData = buf.readProperty();
         SkinShuffle.LOGGER.info("Recieved skin refresh packet from: " + player.getName().getString());
@@ -53,6 +56,18 @@ public class ServerSkinHandling {
             SkinShufflePlayer skinShufflePlayer = (SkinShufflePlayer) player;
             skinShufflePlayer.skinShuffle$refreshSkin();
         });
+    }
+
+    public static PacketByteBuf createEntityIdPacket(int entityId) {
+        return PacketByteBufs.create().writeVarInt(entityId);
+    }
+
+    public static boolean trySendRefreshPlayerListEntry(ServerPlayerEntity player, PacketByteBuf buf) {
+        if (ServerPlayNetworking.canSend(player, REFRESH_PLAYER_LIST_ENTRY_ID)) {
+            ServerPlayNetworking.send(player, REFRESH_PLAYER_LIST_ENTRY_ID, buf);
+            return true;
+        }
+        return false;
     }
 
     public static void init() {

--- a/src/main/java/com/mineblock11/skinshuffle/util/SkinShuffleClientPlayer.java
+++ b/src/main/java/com/mineblock11/skinshuffle/util/SkinShuffleClientPlayer.java
@@ -1,0 +1,25 @@
+/*
+ *
+ *     Copyright (C) 2023 Calum (mineblock11), enjarai
+ *
+ *     This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU Lesser General Public
+ *     License as published by the Free Software Foundation; either
+ *     version 2.1 of the License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *     Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public
+ *     License along with this library; if not, write to the Free Software
+ *     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *     USA
+ */
+
+package com.mineblock11.skinshuffle.util;
+
+public interface SkinShuffleClientPlayer {
+    void skinShuffle$refreshPlayerListEntry();
+}


### PR DESCRIPTION
The main idea: do not completely reload the player entity for people with the mod installed. 

For players with the mod, one packet is simply sent indicating that they need to update the play list entry, which contains the cached old skin.

I know you are working on updating the server side of the mod, this solution may be temporary until you come up with a better implementation.

Tested this on two local 1.20.4 clients with no other mods